### PR TITLE
Fix XML C parser

### DIFF
--- a/itools/srx/srx.py
+++ b/itools/srx/srx.py
@@ -67,9 +67,7 @@ class SRXFile(TextFile):
                         self.header['formathandle_'+type_value] = include
                     # languagerule
                     elif tag_name == 'languagerule':
-                        languagerulename = str(
-                                            attrs[None, 'languagerulename'],
-                                            encoding)
+                        languagerulename = attrs[None, 'languagerulename']
                         current_language =\
                             self.language_rules[languagerulename] = []
                     # rule
@@ -82,15 +80,13 @@ class SRXFile(TextFile):
                             current_break = break_value.lower() != 'no'
                     # languagemap
                     elif tag_name == 'languagemap':
-                        languagepattern = str(
-                            attrs[None, 'languagepattern'], encoding)
-                        languagerulename= str(
-                            attrs[None, 'languagerulename'], encoding)
+                        languagepattern = attrs[None, 'languagepattern']
+                        languagerulename= attrs[None, 'languagerulename']
                         self.map_rules.append((languagepattern,
                                               languagerulename))
                 current_text = ''
             elif type == TEXT:
-                current_text = str(value, encoding)
+                current_text = value
             elif type == END_ELEMENT:
                 tag_uri, tag_name = value
                 if tag_uri == srx_uri:

--- a/itools/xml/__init__.py
+++ b/itools/xml/__init__.py
@@ -22,9 +22,9 @@ from .namespaces import XMLNamespace, xml_uri, xmlns_uri
 from .namespaces import register_namespace, get_namespace, has_namespace
 from .namespaces import ElementSchema, get_element_schema, get_attr_datatype
 from .namespaces import is_empty
-from parser import XMLParser, DocType, register_dtd, XMLError, XML_DECL
-from parser import DOCUMENT_TYPE, START_ELEMENT, END_ELEMENT, TEXT, COMMENT
-from parser import PI, CDATA
+from .parser import XMLParser, DocType, register_dtd, XMLError, XML_DECL
+from .parser import DOCUMENT_TYPE, START_ELEMENT, END_ELEMENT, TEXT, COMMENT
+from .parser import PI, CDATA
 from .utils import is_xml_stream, xml_to_text
 from .xml import Element, stream_to_str, get_element, find_end
 from .xml import get_qname, get_attribute_qname, get_end_tag, get_doctype

--- a/itools/xml/namespaces.py
+++ b/itools/xml/namespaces.py
@@ -22,7 +22,7 @@ from warnings import warn
 # Import from itools
 from itools.core import proto_lazy_property, prototype
 from itools.datatypes import String
-from parser import XMLError
+from .parser import XMLError
 
 
 """

--- a/itools/xml/parser.c
+++ b/itools/xml/parser.c
@@ -57,7 +57,7 @@ struct _Parser
   gint source_type;
   union
   {
-    gchar *cursor;
+    const gchar *cursor;
     FILE *file;
   } source;
   gint source_row;
@@ -332,10 +332,10 @@ _parser_error (Parser * parser, ErrorEvent * event, gchar * msg)
 
 
 gchar *
-intern_string (gchar * str)
+intern_string (const gchar * str)
 {
   HStrTree *node;
-  gchar *cursor;
+  const gchar *cursor;
 
   node = intern_strings_tree;
 
@@ -401,7 +401,7 @@ parser_search_namespace (Parser * parser, gchar * prefix)
 
 
 void
-parser_push_namespace (Parser * parser, gchar * prefix, gchar * uri)
+parser_push_namespace (Parser * parser, gchar * prefix, const gchar * uri)
 {
   Namespace *namespace;
 
@@ -1310,7 +1310,7 @@ parser_read_BOM (Parser * parser)
  *************************************************************************/
 
 Parser *
-parser_new (gchar * data, FILE * file, DocType * doctype)
+parser_new (const gchar * data, FILE * file, DocType * doctype)
 {
   Parser *parser;
 
@@ -1409,7 +1409,7 @@ parser_free (Parser * parser)
 
 
 void
-parser_add_namespace (Parser * parser, gchar * prefix, gchar * uri)
+parser_add_namespace (Parser * parser, const gchar * prefix, const gchar * uri)
 {
   parser_push_namespace (parser, intern_string (prefix), uri);
 }

--- a/itools/xml/parser.h
+++ b/itools/xml/parser.h
@@ -159,14 +159,14 @@ typedef union
 /* if data != NULL source = data
  * else            source = file
  */
-Parser *parser_new (gchar * data, FILE * file, DocType * doctype);
+Parser *parser_new (const gchar * data, FILE * file, DocType * doctype);
 void parser_free (Parser * parser);
 
 
 /**********************************************
  * Add a prefix/namespace in namespaces table *
  **********************************************/
-void parser_add_namespace (Parser * parser, gchar * prefix, gchar * uri);
+void parser_add_namespace (Parser * parser, const gchar * prefix, const gchar * uri);
 
 
 /*********************

--- a/itools/xml/pyparser.c
+++ b/itools/xml/pyparser.c
@@ -516,22 +516,19 @@ XMLParser_init (XMLParser * self, PyObject * args, PyObject * kwds)
       doctype = ((PyDocType *) py_doctype)->doctype;
     }
 
-  int fd = PyObject_AsFileDescriptor(source);
-
   /* Check the source */
   if (PyUnicode_CheckExact (source))
     {
       /* Create the parser object */
       parser = parser_new (PyUnicode_AsUTF8 (source), NULL, doctype);
     }
-  else if (fd != -1)
-    {
-      parser = parser_new (NULL, fdopen(fd, "w"), doctype);
-    }
   else
     {
-      PyErr_SetString (PyExc_TypeError, "argument 1 must be string or file");
-      return -1;
+      int fd = PyObject_AsFileDescriptor(source);
+      if (fd == -1)
+        return -1;
+
+      parser = parser_new (NULL, fdopen(fd, "w"), doctype);
     }
 
   /* End of the creation of the parser object */

--- a/itools/xml/pyparser.c
+++ b/itools/xml/pyparser.c
@@ -729,10 +729,9 @@ static PyMethodDef module_methods[] = {
 #define PyMODINIT_FUNC void
 #endif
 
-static struct PyModuleDef Combinations =
-{
+static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
-    "Combinations", /* name of module */
+    "parser", /* name of module */
     "usage: Combinations.uniqueCombinations(lstSortableItems, comboSize)\n", /* module documentation, may be NULL */
     -1,   /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
     module_methods
@@ -740,7 +739,7 @@ static struct PyModuleDef Combinations =
 
 /* Declaration */
 PyMODINIT_FUNC
-initparser (void)
+PyInit_parser(void)
 {
   /* TODO Make verifications / destructions ... */
   PyObject *module;
@@ -749,7 +748,7 @@ initparser (void)
   XMLParserType.tp_iter = PyObject_SelfIter;
 
   /* Register parser */
-  module = PyModule_Create(&Combinations);
+  module = PyModule_Create(&moduledef);
   if (module == NULL)
     return NULL;
 
@@ -781,5 +780,6 @@ initparser (void)
   PyModule_AddIntConstant (module, "COMMENT", COMMENT);
   PyModule_AddIntConstant (module, "PI", PI);
   PyModule_AddIntConstant (module, "CDATA", CDATA);
-  return 0;
+
+  return module;
 }

--- a/itools/xml/pyparser.c
+++ b/itools/xml/pyparser.c
@@ -490,7 +490,7 @@ XMLParser_init (XMLParser * self, PyObject * args, PyObject * kwds)
   Parser *parser;
 
   PyObject *py_prefix, *py_uri;
-  char *prefix, *uri;
+  const char *prefix, *uri;
   Py_ssize_t pos = 0;
 
 

--- a/itools/xml/utils.py
+++ b/itools/xml/utils.py
@@ -19,7 +19,7 @@
 from types import GeneratorType
 
 # Import from itools
-from parser import XMLParser, TEXT, XML_DECL
+from .parser import XMLParser, TEXT, XML_DECL
 
 
 

--- a/itools/xml/xml.py
+++ b/itools/xml/xml.py
@@ -22,7 +22,7 @@
 # Import from itools
 from itools.datatypes import XMLAttribute, XMLContent
 from .namespaces import get_namespace, is_empty
-from parser import START_ELEMENT, END_ELEMENT
+from .parser import START_ELEMENT, END_ELEMENT
 
 
 # Serialize

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-magic==0.4.24
 junitxml
 gevent==21.8.0
 cryptography==36.0.1
+pillow

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import print_function
 
+from setuptools import setup
+
 # Import from the Standard Library
 from distutils.core import Extension
-from distutils.core import setup
 from os.path import join as join_path
 from pip._internal.req import parse_requirements
 from sys import stderr


### PR DESCRIPTION
For the record I've done:

```
$ python3.9 -m venv --system-site-packages venv39
(venv39) $ source venv39/bin/activate
(venv39) $ pip install -r requirements.txt
(venv39) $ python setup.py build_ext --inplace
(venv39) $ python -c "import itools.xml"
```

If `buil_ext` is called again another error happens:

```
(venv39) $ python setup.py build_ext --inplace
ENV VAR FERNET_KEY FOR FERNET ENCRYPTION KEY IS NOT SET, SENSITIVE VALUES WILL NOT BE ENCRYPTED
Traceback (most recent call last):
  File "/home/jdavid/sandboxes/itools/setup.py", line 97, in <module>
    from itools.pkg.utils import setup as itools_setup
  [...]
  File "/home/jdavid/sandboxes/itools/itools/database/backends/lfs.py", line 52, in get_handler_data
    return f.read()
  File "/usr/lib/python3.9/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xde in position 0: invalid continuation byte
```

But this is unrelated to the XML parser.

Most errors and most work upgrading to Python 3 will come from the fact that: with Python 3 everywhere Unicode strings are returned instead of Byte strings.